### PR TITLE
Added nil check for missing environment key

### DIFF
--- a/rancher_service.rb
+++ b/rancher_service.rb
@@ -11,7 +11,15 @@ class RancherService
 
   def upgrade
     strategy = current_service
-    strategy['startFirst'] = !strategy['launchConfig']['environment'].key?('RANCHER_NON_OVERLAPPED_UPGRADES')
+    environment = strategy['launchConfig']['environment'];
+    
+    # we have to check for nil because the environment key is optional
+    if environment.nil?
+      strategy['startFirst'] = false
+    else
+      strategy['startFirst'] = !environment.key?('RANCHER_NON_OVERLAPPED_UPGRADES')
+    end
+    
     payload = {
       inServiceStrategy: strategy
     }


### PR DESCRIPTION
I got a "no method" exception when trying to upgrade a service in Rancher. It turns out that the environment key within lauchConfig in the rancher json service api is optional and might or might not be there. In my service I have no environment variables. I added in a nil check so that we don't try to call the key method on a null object. I defaulted strategy['startFirst'] = false if environment is missing.

Here's the Stack Trace:

undefined method `key?' for nil:NilClass
/ruby-app/rancher_service.rb:14:in`upgrade'
/ruby-app/upgrade_job.rb:15:in `block in perform'
/ruby-app/upgrade_job.rb:14:in`each'
/ruby-app/upgrade_job.rb:14:in `perform'
/var/lib/gems/2.3.0/gems/activejob-4.2.6/lib/active_job/execution.rb:32:in`block in perform_now'
/var/lib/gems/2.3.0/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:117:in `call'
/var/lib/gems/2.3.0/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:555:in`block (2 levels) in compile'
/var/lib/gems/2.3.0/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:505:in `call'
/var/lib/gems/2.3.0/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:498:in`block (2 levels) in around'
/var/lib/gems/2.3.0/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:343:in `block (2 levels) in simple'
/var/lib/gems/2.3.0/gems/i18n-0.7.0/lib/i18n.rb:257:in`with_locale'
/var/lib/gems/2.3.0/gems/activejob-4.2.6/lib/active_job/translation.rb:7:in `block (2 levels) in <module:Translation>'
/var/lib/gems/2.3.0/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:441:in`instance_exec'
/var/lib/gems/2.3.0/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:441:in `block in make_lambda'
/var/lib/gems/2.3.0/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:342:in`block in simple'
/var/lib/gems/2.3.0/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:497:in `block in around'
/var/lib/gems/2.3.0/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:505:in`call'
/var/lib/gems/2.3.0/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:498:in `block (2 levels) in around'
/var/lib/gems/2.3.0/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:343:in`block (2 levels) in simple'
/var/lib/gems/2.3.0/gems/activejob-4.2.6/lib/active_job/logging.rb:23:in `block (4 levels) in <module:Logging>'
/var/lib/gems/2.3.0/gems/activesupport-4.2.6/lib/active_support/notifications.rb:164:in`block in instrument'
/var/lib/gems/2.3.0/gems/activesupport-4.2.6/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
/var/lib/gems/2.3.0/gems/activesupport-4.2.6/lib/active_support/notifications.rb:164:in`instrument'
/var/lib/gems/2.3.0/gems/activejob-4.2.6/lib/active_job/logging.rb:22:in `block (3 levels) in <module:Logging>'
/var/lib/gems/2.3.0/gems/activejob-4.2.6/lib/active_job/logging.rb:43:in`block in tag_logger'
/var/lib/gems/2.3.0/gems/activesupport-4.2.6/lib/active_support/tagged_logging.rb:68:in `block in tagged'
/var/lib/gems/2.3.0/gems/activesupport-4.2.6/lib/active_support/tagged_logging.rb:26:in`tagged'
/var/lib/gems/2.3.0/gems/activesupport-4.2.6/lib/active_support/tagged_logging.rb:68:in `tagged'
/var/lib/gems/2.3.0/gems/activejob-4.2.6/lib/active_job/logging.rb:43:in`tag_logger'
/var/lib/gems/2.3.0/gems/activejob-4.2.6/lib/active_job/logging.rb:19:in `block (2 levels) in <module:Logging>'
/var/lib/gems/2.3.0/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:441:in`instance_exec'
/var/lib/gems/2.3.0/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:441:in `block in make_lambda'
/var/lib/gems/2.3.0/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:342:in`block in simple'
/var/lib/gems/2.3.0/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:497:in `block in around'
/var/lib/gems/2.3.0/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:505:in`call'
/var/lib/gems/2.3.0/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:92:in `__run_callbacks__'
/var/lib/gems/2.3.0/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:778:in`_run_perform_callbacks'
/var/lib/gems/2.3.0/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:81:in `run_callbacks'
/var/lib/gems/2.3.0/gems/activejob-4.2.6/lib/active_job/execution.rb:31:in`perform_now'
/var/lib/gems/2.3.0/gems/activejob-4.2.6/lib/active_job/execution.rb:21:in `execute'
/var/lib/gems/2.3.0/gems/activejob-4.2.6/lib/active_job/queue_adapters/resque_adapter.rb:46:in`perform'
